### PR TITLE
upgradeSpringTestVersion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <spotless.version>2.4.0</spotless.version>
         <springboot.version>1.3.3.RELEASE</springboot.version>
         <springweb.version>4.2.5.RELEASE</springweb.version>
-	<springtest.version>2.5</springtest.version>
+	    <springtest.version>4.2.5.RELEASE</springtest.version>
         <swaggerannotation.version>1.5.13</swaggerannotation.version>
         <swagger.version>2.6.1</swagger.version>
         <truth.version>0.30</truth.version>


### PR DESCRIPTION
Problem:
- Job Planner relies on the sprint test 4.2.5.RELEASE
- Before the version was applied implicit and gradle chose 4.2.5.RELEASE implicit.

Solution:
- Upgrade the sprint test version to 4.2.5.RELEASE