### PR TITLE
Upgrade keycloak related dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,13 +30,14 @@
 		<hibernate.version>5.3.32.Final</hibernate.version>
 		<hibernatejpa.version>1.0.2.Final</hibernatejpa.version>
 		<hsqldb.version>2.7.2</hsqldb.version>
-		<httpclient.version>4.5.13</httpclient.version>
+		<httpclient.version>4.5.14</httpclient.version>
 		<ical4j.version>2.0.0</ical4j.version>
 		<!-- 2.6.6 version was a transitive dependency version used in programming-extension-vfsprovider 
 			=> activeeon:vfs-s3:2.4.7 => com.amazonaws:aws-java-sdk-core:1.11.22 -->
 		<javax.ws.rs.version>2.0.1</javax.ws.rs.version>
-		<jacksondatabind.version>2.13.4.2</jacksondatabind.version>
-		<jackson.version>2.13.4</jackson.version>
+		<jacksondatabind.version>2.16.1</jacksondatabind.version>
+		<jakarta.version>2.1.2</jakarta.version>
+		<jackson.version>2.16.1</jackson.version>
 		<jersey.version>1.19.4</jersey.version>
 		<glassfish.version>2.41</glassfish.version>
 		<jclouds.version>1.9.3</jclouds.version>
@@ -364,6 +365,11 @@
 				<groupId>com.fasterxml.jackson.dataformat</groupId>
 				<artifactId>jackson-dataformat-cbor</artifactId>
 				<version>${jackson.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>jakarta.activation</groupId>
+				<artifactId>jakarta.activation-api</artifactId>
+				<version>${jakarta.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.codehaus.jackson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
 			=> activeeon:vfs-s3:2.4.7 => com.amazonaws:aws-java-sdk-core:1.11.22 -->
 		<javax.ws.rs.version>2.0.1</javax.ws.rs.version>
 		<jacksondatabind.version>2.16.1</jacksondatabind.version>
-		<jakarta.version>2.1.2</jakarta.version>
 		<jackson.version>2.16.1</jackson.version>
+		<jakarta.version>2.1.2</jakarta.version>
 		<jersey.version>1.19.4</jersey.version>
 		<glassfish.version>2.41</glassfish.version>
 		<jclouds.version>1.9.3</jclouds.version>
@@ -649,7 +649,7 @@
 			<dependency>
 				<groupId>com.google.code.gson</groupId>
 				<artifactId>gson</artifactId>
-				<version>${gson.version}</version>
+				<version>${gsupgrade-keycloak-related-dependencieson.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -649,7 +649,7 @@
 			<dependency>
 				<groupId>com.google.code.gson</groupId>
 				<artifactId>gson</artifactId>
-				<version>${gsupgrade-keycloak-related-dependencieson.version}</version>
+				<version>${gson.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Upgrade the following dependencies to the versions mentioned in **bold**:

- jakarta.activation:jakarta.activation-api:**2.1.2**

- com.fasterxml.jackson.core:jackson-databind:**2.16.1**
- com.fasterxml.jackson.core:jackson-core:**2.16.1**
- com.fasterxml.jackson.core:jackson-annotations:**2.16.1**

- org.apache.httpcomponents:httpclient:**4.5.14**

- org.bouncycastle:bcprov-jdk18on:**1.77**
- org.bouncycastle:bcutil-jdk18on:**1.77**